### PR TITLE
Tests and semtool stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Comb is a library that simplifies building parsers in Go.
 
 For me, it has got the optimal feature set:
 1. Simple maintainability of a normal library thanks to being a parser combinator library.
-1. Report errors with exact (line and column) position and code snippet.
-1. Report **multiple** errors.
-1. UNICODE support.
+1. Report errors with the line and column position and code snippet.
+1. Reporting of **multiple** errors.
+1. UNICODE support (working on UTF-8 encoded UNICODE code points instead of bytes if requested).
 1. Support for binary input (including byte position and hex dump for errors).
 1. Type safety (including filling arbitrary typed data) using generics.
 1. Idiomatic Go code (no generated code, ...).

--- a/cmb/characters.go
+++ b/cmb/characters.go
@@ -68,14 +68,14 @@ func AnyChar() comb.Parser[rune] {
 // '\\' 'x'[0-9a-fA-F][0-9a-fA-F] // hexadecimal escapes (possibly illegal UTF-8)
 // '\\' 'u'[0-9a-fA-F]{4,4} // 4 hex digits for a 16 bit Unicode character
 // '\\' 'U'[0-9a-fA-F]{8,8} // 8 hex digits for a 32 bit Unicode character
-func QuotedChar(expected, forbiddenASCIIChars, additionalEscapedChars string) comb.Parser[rune] {
+func QuotedChar(expected, forbiddenChars, additionalEscapedChars string) comb.Parser[rune] {
 	parse := func(state comb.State) (comb.State, rune, *comb.ParserError) {
 		input := state.CurrentString()
 		r, size, pErr := decodeRune(input, expected, state)
 		if pErr != nil {
 			return state, r, pErr
 		}
-		if strings.ContainsRune(forbiddenASCIIChars, r) { // handle forbidden chars
+		if strings.ContainsRune(forbiddenChars, r) { // handle forbidden chars
 			return state, utf8.RuneError, state.NewSyntaxError("%s found %q", expected, r)
 		}
 		if r == '\\' { // handle additional escaped chars
@@ -93,6 +93,35 @@ func QuotedChar(expected, forbiddenASCIIChars, additionalEscapedChars string) co
 			return state, utf8.RuneError, state.NewSyntaxError("%s (%v)", expected, err)
 		}
 		return state.MoveBy(len(input) - len(rest)), c, nil
+	}
+
+	return comb.NewParser[rune](expected, parse, Forbidden())
+}
+
+func CharClassChar(expected string, classRunes []rune, classRanges [][]rune) comb.Parser[rune] {
+	if len(classRunes) == 0 && len(classRanges) == 0 {
+		panic("no class runes and no class ranges provided")
+	}
+	for i, cr := range classRanges {
+		if len(cr) < 2 {
+			panic(fmt.Sprintf("class ranges must contain two runes (index %d has only %d)", i, len(cr)))
+		}
+	}
+	parse := func(state comb.State) (comb.State, rune, *comb.ParserError) {
+		input := state.CurrentString()
+		r, size, pErr := decodeRune(input, expected, state)
+		if pErr != nil {
+			return state, r, pErr
+		}
+		if slices.Contains(classRunes, r) {
+			return state.MoveBy(size), r, nil
+		}
+		for _, cr := range classRanges {
+			if r >= cr[0] && r <= cr[1] {
+				return state.MoveBy(size), r, nil
+			}
+		}
+		return state, utf8.RuneError, state.NewSyntaxError("%s (got %q)", expected, r)
 	}
 
 	return comb.NewParser[rune](expected, parse, Forbidden())

--- a/cmb/characters.go
+++ b/cmb/characters.go
@@ -22,12 +22,9 @@ func Char(char rune) comb.Parser[rune] {
 	expected := strconv.QuoteRune(char)
 
 	parse := func(state comb.State) (comb.State, rune, *comb.ParserError) {
-		r, size := utf8.DecodeRuneInString(state.CurrentString())
-		if r == utf8.RuneError {
-			if size == 0 {
-				return state, utf8.RuneError, state.NewSyntaxError("%s (at EOF)", expected)
-			}
-			return state, utf8.RuneError, state.NewSyntaxError("%s (got UTF-8 error)", expected)
+		r, size, pErr := decodeRune(state.CurrentString(), expected, state)
+		if pErr != nil {
+			return state, r, pErr
 		}
 		if r != char {
 			return state, utf8.RuneError, state.NewSyntaxError("%s (got %q)", expected, r)
@@ -46,18 +43,70 @@ func AnyChar() comb.Parser[rune] {
 	expected := "any character"
 
 	parse := func(state comb.State) (comb.State, rune, *comb.ParserError) {
-		r, size := utf8.DecodeRuneInString(state.CurrentString())
-		if r == utf8.RuneError {
-			if size == 0 {
-				return state, utf8.RuneError, state.NewSyntaxError(expected + " (at EOF)")
-			}
-			return state, utf8.RuneError, state.NewSyntaxError(expected + " (got UTF-8 error)")
+		r, size, pErr := decodeRune(state.CurrentString(), expected, state)
+		if pErr != nil {
+			return state, r, pErr
 		}
-
 		return state.MoveBy(size), r, nil
 	}
 
 	return comb.NewParser[rune](expected, parse, Forbidden())
+}
+
+// QuotedChar parses and returns a single rune.
+// forbiddenChars is a string containing all characters that are forbidden to be used without escaping.
+// additionalEscapedChars is a string containing all characters that have to be escaped next to the standard ones.
+// In almost all cases forbiddenChars and additionalEscapedChars should be the same.
+//
+// This parser is NOT a good candidate for SafeSpot and has a Forbidden recoverer.
+// But parsers using QuotedChar in a more constrained context are a good candidate for SafeSpot.
+//
+// The parser returns an error result only at the end of the input or in case of a UTF-8 error.
+// The standard escapes are:
+// '\\' [abefnrtv\\]  // standard ANSI escapes
+// '\\' [0-3][0-7][0-7] // octal escapes (possibly illegal UTF-8)
+// '\\' 'x'[0-9a-fA-F][0-9a-fA-F] // hexadecimal escapes (possibly illegal UTF-8)
+// '\\' 'u'[0-9a-fA-F]{4,4} // 4 hex digits for a 16 bit Unicode character
+// '\\' 'U'[0-9a-fA-F]{8,8} // 8 hex digits for a 32 bit Unicode character
+func QuotedChar(expected, forbiddenASCIIChars, additionalEscapedChars string) comb.Parser[rune] {
+	parse := func(state comb.State) (comb.State, rune, *comb.ParserError) {
+		input := state.CurrentString()
+		r, size, pErr := decodeRune(input, expected, state)
+		if pErr != nil {
+			return state, r, pErr
+		}
+		if strings.ContainsRune(forbiddenASCIIChars, r) { // handle forbidden chars
+			return state, utf8.RuneError, state.NewSyntaxError("%s found %q", expected, r)
+		}
+		if r == '\\' { // handle additional escaped chars
+			backslashLen := len("\\") // should be always 1; but better safe than sorry
+			r, size, pErr = decodeRune(input[backslashLen:], expected, state)
+			if pErr != nil {
+				return state, r, pErr
+			}
+			if strings.ContainsRune(additionalEscapedChars, r) {
+				return state.MoveBy(backslashLen + size), r, nil
+			}
+		}
+		c, _, rest, err := strconv.UnquoteChar(input, 0) // all other escaped chars are handled here
+		if err != nil {
+			return state, utf8.RuneError, state.NewSyntaxError("%s (%v)", expected, err)
+		}
+		return state.MoveBy(len(input) - len(rest)), c, nil
+	}
+
+	return comb.NewParser[rune](expected, parse, Forbidden())
+}
+
+func decodeRune(input string, expected string, state comb.State) (rune, int, *comb.ParserError) {
+	r, size := utf8.DecodeRuneInString(input)
+	if r == utf8.RuneError {
+		if size == 0 {
+			return utf8.RuneError, 0, state.NewSyntaxError(expected + " (at EOF)")
+		}
+		return utf8.RuneError, 1, state.NewSyntaxError(expected + " (got UTF-8 error)")
+	}
+	return r, size, nil
 }
 
 // Byte parses a single byte and matches it with
@@ -117,12 +166,9 @@ func Satisfy(expected string, predicate func(rune) bool) comb.Parser[rune] {
 	var p comb.Parser[rune]
 
 	parse := func(state comb.State) (comb.State, rune, *comb.ParserError) {
-		r, size := utf8.DecodeRuneInString(state.CurrentString())
-		if r == utf8.RuneError {
-			if size == 0 {
-				return state, utf8.RuneError, state.NewSyntaxError("%s (at EOF)", expected)
-			}
-			return state, utf8.RuneError, state.NewSyntaxError("%s (got UTF-8 error)", expected)
+		r, size, pErr := decodeRune(state.CurrentString(), expected, state)
+		if pErr != nil {
+			return state, r, pErr
 		}
 		if !predicate(r) {
 			return state, utf8.RuneError, state.NewSyntaxError("%s (got %q)", expected, r)
@@ -181,50 +227,6 @@ func Bytes(token []byte) comb.Parser[[]byte] {
 	}
 
 	p = comb.NewParser[[]byte](expected, parse, IndexOf(token))
-	return p
-}
-
-// UntilString parses until it finds a token in the input and returns
-// the part of the input that preceded the token.
-// If found, the parser moves beyond the stop string.
-// If the token could not be found, the parser returns an error result.
-//
-// NOTE:
-//   - This function panics if `stop` is empty.
-//   - UntilString is rather dangerous especially in case of error recovery
-//     because it potentially consumes much more input than expected.
-//     In error cases it will usually start earlier because other parsers are skipped.
-//     Especially using it as a `SafeSpot` parser is a bad idea!
-func UntilString(stop string) comb.Parser[string] {
-	var p comb.Parser[string]
-
-	expected := fmt.Sprintf("... %q", stop)
-
-	if stop == "" {
-		panic("stop is empty")
-	}
-
-	parse := func(state comb.State) (comb.State, string, *comb.ParserError) {
-		input := state.CurrentString()
-		i := strings.Index(input, stop)
-		if i == -1 {
-			return state, "", state.NewSyntaxError(expected)
-		}
-
-		newState := state.MoveBy(i + len(stop))
-		return newState, input[:i], nil
-	}
-
-	p = comb.NewParser[string](
-		expected,
-		parse,
-		func(state comb.State, _ interface{}) (int, interface{}) {
-			if strings.Contains(state.CurrentString(), stop) {
-				return 0, nil // this is probably not what the user wants but the only correct value :(
-			}
-			return comb.RecoverWasteTooMuch, nil
-		},
-	)
 	return p
 }
 
@@ -315,7 +317,7 @@ func Alpha0() comb.Parser[string] {
 	return SatisfyMN("letter", 0, math.MaxInt, unicode.IsLetter)
 }
 
-// Alpha1 parses one or more lowercase or uppercase alphabetic characters: a-z, A-Z.
+// Alpha1 parses one or more lowercase or uppercase alphabetic Unicode characters (e.g., a-z or A-Z).
 // In the cases where the input doesn't hold enough data, or a terminating character
 // is found before any matching ones were, the parser returns an error result.
 func Alpha1() comb.Parser[string] {
@@ -324,7 +326,6 @@ func Alpha1() comb.Parser[string] {
 
 // Alphanumeric0 parses zero or more alphabetical or numerical Unicode characters.
 // An '_' is considered a valid character, too.
-// In the cases where the input is empty, or no matching character is found, the parser
 // In the cases where the input is empty, or no matching character is found, the parser
 // returns the input as is.
 func Alphanumeric0() comb.Parser[string] {

--- a/cmb/characters_test.go
+++ b/cmb/characters_test.go
@@ -165,6 +165,118 @@ func BenchmarkAnyChar(b *testing.B) {
 	}
 }
 
+func TestQuotedChar(t *testing.T) {
+	t.Parallel()
+
+	rangeEscapes := "[]-"
+	expected := "range character"
+	testCases := []struct {
+		name          string
+		parser        comb.Parser[rune]
+		input         string
+		wantErr       bool
+		wantOutput    rune
+		wantRemaining string
+	}{
+		{
+			name:          "parsing normal char from single char input should succeed",
+			parser:        cmb.QuotedChar(expected, rangeEscapes, rangeEscapes),
+			input:         "a",
+			wantErr:       false,
+			wantOutput:    'a',
+			wantRemaining: "",
+		}, {
+			name:          "parsing octal char in longer input should succeed",
+			parser:        cmb.QuotedChar(expected, rangeEscapes, rangeEscapes),
+			input:         `\101abc`,
+			wantErr:       false,
+			wantOutput:    'A',
+			wantRemaining: "abc",
+		}, {
+			name:          "parsing hex char should succeed",
+			parser:        cmb.QuotedChar(expected, rangeEscapes, rangeEscapes),
+			input:         `\x41abc`,
+			wantErr:       false,
+			wantOutput:    'A',
+			wantRemaining: "abc",
+		}, {
+			name:          "parsing 16 bit Unicode char should succeed",
+			parser:        cmb.QuotedChar(expected, rangeEscapes, rangeEscapes),
+			input:         `\u1234`,
+			wantErr:       false,
+			wantOutput:    '\u1234',
+			wantRemaining: "",
+		}, {
+			name:          "parsing 32 bit Unicode char should succeed",
+			parser:        cmb.QuotedChar(expected, rangeEscapes, rangeEscapes),
+			input:         `\U0001F600ab`,
+			wantErr:       false,
+			wantOutput:    '\U0001F600',
+			wantRemaining: "ab",
+		}, {
+			name:          "parsing additional escaped char should succeed",
+			parser:        cmb.QuotedChar(expected, rangeEscapes, rangeEscapes),
+			input:         `\-`,
+			wantErr:       false,
+			wantOutput:    '-',
+			wantRemaining: "",
+		}, {
+			name:          "parsing forbidden char should fail",
+			parser:        cmb.QuotedChar(expected, rangeEscapes, rangeEscapes),
+			input:         `]`,
+			wantErr:       true,
+			wantOutput:    utf8.RuneError,
+			wantRemaining: "]",
+		}, {
+			name:          "parsing non-valid Unicode char should fail",
+			parser:        cmb.QuotedChar(expected, rangeEscapes, rangeEscapes),
+			input:         string([]byte{129, 65, 66, 67}),
+			wantErr:       true,
+			wantOutput:    utf8.RuneError,
+			wantRemaining: string([]byte{129, 65, 66, 67}),
+		}, {
+			name:          "parsing empty input should fail",
+			parser:        cmb.QuotedChar(expected, rangeEscapes, rangeEscapes),
+			input:         "",
+			wantErr:       true,
+			wantOutput:    utf8.RuneError,
+			wantRemaining: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc // this is needed for t.Parallel() to work correctly (or the same test case will be executed N times)
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			newState, gotOutput, gotErr := tc.parser.Parse(comb.NewFromString(tc.input, 10))
+			if (gotErr != nil) != tc.wantErr {
+				t.Errorf("got error %v, want error: %t", gotErr, tc.wantErr)
+			}
+
+			t.Logf("got output: %q", gotOutput)
+			if gotOutput != tc.wantOutput {
+				t.Errorf("got output %q, want output %q", gotOutput, tc.wantOutput)
+			}
+
+			gotRemaining := newState.CurrentString()
+			if gotRemaining != tc.wantRemaining {
+				t.Errorf("got remaining %q, want remaining %q", gotRemaining, tc.wantRemaining)
+			}
+		})
+	}
+}
+
+func BenchmarkQuotedChar(b *testing.B) {
+	parser := cmb.QuotedChar("double quoted character", "\"", "\"")
+	input := comb.NewFromString("\"", 10)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = parser.Parse(input)
+	}
+}
+
 func TestByte(t *testing.T) {
 	t.Parallel()
 
@@ -1929,7 +2041,7 @@ func BenchmarkTab(b *testing.B) {
 	}
 }
 
-func TestToken(t *testing.T) {
+func TestString(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
@@ -1987,9 +2099,77 @@ func TestToken(t *testing.T) {
 	}
 }
 
-func BenchmarkToken(b *testing.B) {
+func BenchmarkString(b *testing.B) {
 	parser := cmb.String("Bonjour")
 	input := comb.NewFromString("Bonjour tout le monde", 0)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = parser.Parse(input)
+	}
+}
+
+func TestBytes(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		parser        comb.Parser[[]byte]
+		input         []byte
+		wantErr       bool
+		wantOutput    []byte
+		wantRemaining []byte
+	}{
+		{
+			name:          "parsing a token from an input starting with it should succeed",
+			parser:        cmb.Bytes([]byte("Bon")),
+			input:         []byte("Bon tout"),
+			wantErr:       false,
+			wantOutput:    []byte("Bon"),
+			wantRemaining: []byte(" tout"),
+		},
+		{
+			name:          "parsing a token from a non-matching input should fail",
+			parser:        cmb.Bytes([]byte("Bon")),
+			input:         []byte("Hello tout"),
+			wantErr:       true,
+			wantOutput:    []byte{},
+			wantRemaining: []byte("Hello tout"),
+		},
+		{
+			name:          "parsing a token from an empty input should fail",
+			parser:        cmb.Bytes([]byte("Bon")),
+			input:         []byte{},
+			wantErr:       true,
+			wantOutput:    []byte{},
+			wantRemaining: []byte{},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc // this is needed for t.Parallel() to work correctly (or the same test case will be executed N times)
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			newState, gotOutput, gotErr := tc.parser.Parse(comb.NewFromBytes(tc.input, 10))
+			if (gotErr != nil) != tc.wantErr {
+				t.Errorf("got error %v, want error: %t", gotErr, tc.wantErr)
+			}
+
+			if !bytes.Equal(gotOutput, tc.wantOutput) {
+				t.Errorf("got output 0x%x, want output 0x%x", gotOutput, tc.wantOutput)
+			}
+			gotRemaining := newState.CurrentBytes()
+			if !bytes.Equal(gotRemaining, tc.wantRemaining) {
+				t.Errorf("got remaining %#v, want remaining %#v", gotRemaining, tc.wantRemaining)
+			}
+		})
+	}
+}
+
+func BenchmarkBytes(b *testing.B) {
+	parser := cmb.Bytes([]byte("Bonjour"))
+	input := comb.NewFromBytes([]byte("Bonjour tout le monde"), 0)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/cmb/characters_test.go
+++ b/cmb/characters_test.go
@@ -277,6 +277,96 @@ func BenchmarkQuotedChar(b *testing.B) {
 	}
 }
 
+func TestCharClassChar(t *testing.T) {
+	t.Parallel()
+
+	expected := "range character"
+	testCases := []struct {
+		name          string
+		parser        comb.Parser[rune]
+		input         string
+		wantErr       bool
+		wantOutput    rune
+		wantRemaining string
+	}{
+		{
+			name:          "parsing given char from single char input should succeed",
+			parser:        cmb.CharClassChar(expected, []rune{'a', 'b', 'c'}, nil),
+			input:         "c",
+			wantErr:       false,
+			wantOutput:    'c',
+			wantRemaining: "",
+		}, {
+			name:          "parsing range char in longer input should succeed",
+			parser:        cmb.CharClassChar(expected, nil, [][]rune{{'0', '9'}, {'c', 'd'}}),
+			input:         `1abc`,
+			wantErr:       false,
+			wantOutput:    '1',
+			wantRemaining: "abc",
+		}, {
+			name:          "parsing square bracket should succeed",
+			parser:        cmb.CharClassChar(expected, []rune{'[', ']', '-'}, nil),
+			input:         `[abc`,
+			wantErr:       false,
+			wantOutput:    '[',
+			wantRemaining: "abc",
+		}, {
+			name:          "parsing 16 bit Unicode char should succeed",
+			parser:        cmb.CharClassChar(expected, []rune{'\u1234'}, nil),
+			input:         "\u1234",
+			wantErr:       false,
+			wantOutput:    '\u1234',
+			wantRemaining: "",
+		}, {
+			name:          "parsing char outside range should fail",
+			parser:        cmb.CharClassChar(expected, []rune{'1', '2', '3'}, [][]rune{{'a', 'm'}}),
+			input:         `n`,
+			wantErr:       true,
+			wantOutput:    utf8.RuneError,
+			wantRemaining: "n",
+		}, {
+			name:          "parsing empty input should fail",
+			parser:        cmb.CharClassChar(expected, []rune{'1', '2', '3'}, [][]rune{{'a', 'm'}}),
+			input:         "",
+			wantErr:       true,
+			wantOutput:    utf8.RuneError,
+			wantRemaining: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc // this is needed for t.Parallel() to work correctly (or the same test case will be executed N times)
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			newState, gotOutput, gotErr := tc.parser.Parse(comb.NewFromString(tc.input, 10))
+			if (gotErr != nil) != tc.wantErr {
+				t.Errorf("got error %v, want error: %t", gotErr, tc.wantErr)
+			}
+
+			t.Logf("got output: %q", gotOutput)
+			if gotOutput != tc.wantOutput {
+				t.Errorf("got output %q, want output %q", gotOutput, tc.wantOutput)
+			}
+
+			gotRemaining := newState.CurrentString()
+			if gotRemaining != tc.wantRemaining {
+				t.Errorf("got remaining %q, want remaining %q", gotRemaining, tc.wantRemaining)
+			}
+		})
+	}
+}
+
+func BenchmarkCharClassChar(b *testing.B) {
+	parser := cmb.CharClassChar("range 'a' - 'b'", nil, [][]rune{{'a', 'b'}})
+	input := comb.NewFromString("b", 10)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = parser.Parse(input)
+	}
+}
+
 func TestByte(t *testing.T) {
 	t.Parallel()
 

--- a/cmb/combinators.go
+++ b/cmb/combinators.go
@@ -143,6 +143,70 @@ func StringUntil[Output any](p comb.Parser[Output]) comb.Parser[string] {
 	return bp
 }
 
+// BytesUntil parses everything until the provided parser succeeds.
+// It uses the recoverer of the provided parser.
+// This is great for performance.
+//
+// NOTE:
+//   - BytesUntil panics during the construction of the parser if the provided parser
+//     has a Forbidden recoverer.
+//   - BytesUntil can't be used as SafeSpot, but the provided parser can be a SafeSpot.
+//   - BytesUntil DOES consume the matching parsers input.
+func BytesUntil[Output any](p comb.Parser[Output]) comb.Parser[[]byte] {
+	var bp comb.Parser[[]byte]
+
+	// call Recoverer to find a Forbidden recoverer during the construction phase and panic
+	if !p.IsStepRecoverer() {
+		waste, _ := p.Recover(comb.NewFromBytes([]byte{}, 0), nil)
+		if waste == comb.RecoverNever {
+			panic("a parser with a Forbidden recoverer can't be used with BytesUntil")
+		}
+	}
+
+	bp = comb.NewBranchParser[[]byte](
+		"BytesUntil",
+		func() []comb.AnyParser {
+			return []comb.AnyParser{p}
+		}, func(
+			childID int32,
+			startState, state comb.State,
+			childOut interface{},
+			childErr *comb.ParserError,
+			data interface{},
+		) (comb.State, []byte, *comb.ParserError, interface{}) {
+			zero := []byte{}
+			if childID >= 0 { // bottom-up
+				return state, zero, childErr, nil // we don't know better
+			} else { // top-down
+				var err *comb.ParserError
+				startState = state
+				nState := state
+				id := bp.ID()
+				if p.IsStepRecoverer() {
+					for nState, _, err = p.ParseAny(id, state); err != nil && !state.AtEnd(); nState, _, err = p.ParseAny(id, state) {
+						state = state.Delete1()
+					}
+				} else {
+					waste, _ := p.Recover(startState, nil)
+					if waste < 0 {
+						err = startState.NewSemanticError("just signaling failure")
+					} else {
+						state = startState.MoveBy(waste)
+						nState, _, err = p.ParseAny(id, state) // should never fail (if recoverer is working)
+					}
+				}
+				if err != nil {
+					return startState, zero,
+						startState.NewSyntaxError("unable to find %s in the input", p.Expected()),
+						nil
+				}
+				return nState, startState.BytesTo(state), nil, nil
+			}
+		},
+	)
+	return bp
+}
+
 // Assign returns the provided value if the parser succeeds, otherwise
 // it returns an error result.
 func Assign[Output1, Output2 any](value Output1, parser comb.Parser[Output2]) comb.Parser[Output1] {
@@ -239,5 +303,7 @@ func Map5[PO1, PO2, PO3, PO4, PO5 any, MO any](
 	parse1 comb.Parser[PO1], parse2 comb.Parser[PO2], parse3 comb.Parser[PO3], parse4 comb.Parser[PO4], parse5 comb.Parser[PO5],
 	fn func(PO1, PO2, PO3, PO4, PO5) (MO, error),
 ) comb.Parser[MO] {
-	return MapN("Map5", parse1, parse2, parse3, parse4, parse5, 5, nil, nil, nil, nil, fn)
+	return MapN(
+		"Map5",
+		parse1, parse2, parse3, parse4, parse5, 5, nil, nil, nil, nil, fn)
 }

--- a/cmb/combinators_test.go
+++ b/cmb/combinators_test.go
@@ -1,4 +1,4 @@
-package cmb
+package cmb_test
 
 import (
 	"errors"
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/flowdev/comb"
+	"github.com/flowdev/comb/cmb"
 )
 
 func TestOptional(t *testing.T) {
@@ -21,21 +22,21 @@ func TestOptional(t *testing.T) {
 		{
 			name:       "matching parser should succeed",
 			input:      "\r\n123",
-			parser:     Optional(CRLF()),
+			parser:     cmb.Optional(cmb.CRLF()),
 			wantErr:    false,
 			wantOutput: "\r\n",
 		},
 		{
 			name:       "no match should succeed",
 			input:      "123",
-			parser:     Optional(CRLF()),
+			parser:     cmb.Optional(cmb.CRLF()),
 			wantErr:    false,
 			wantOutput: "",
 		},
 		{
 			name:       "empty input should succeed",
 			input:      "",
-			parser:     Optional(CRLF()),
+			parser:     cmb.Optional(cmb.CRLF()),
 			wantErr:    false,
 			wantOutput: "",
 		},
@@ -58,7 +59,7 @@ func TestOptional(t *testing.T) {
 }
 
 func BenchmarkOptional(b *testing.B) {
-	parser := Optional(CR())
+	parser := cmb.Optional(cmb.CR())
 	input := comb.NewFromString("\r123", 0)
 
 	b.ResetTimer()
@@ -80,14 +81,13 @@ func TestPeek(t *testing.T) {
 		{
 			name:       "matching parser should succeed",
 			input:      "abcd;",
-			parser:     Peek(Alpha1()),
+			parser:     cmb.Peek(cmb.Alpha1()),
 			wantErr:    false,
 			wantOutput: "abcd",
-		},
-		{
+		}, {
 			name:       "non matching parser should fail",
 			input:      "123;",
-			parser:     Peek(Alpha1()),
+			parser:     cmb.Peek(cmb.Alpha1()),
 			wantErr:    true,
 			wantOutput: "",
 		},
@@ -110,7 +110,121 @@ func TestPeek(t *testing.T) {
 }
 
 func BenchmarkPeek(b *testing.B) {
-	parser := Peek(Alpha1())
+	parser := cmb.Peek(cmb.Alpha1())
+	input := comb.NewFromString("abcd;", 0)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = parser.Parse(input)
+	}
+}
+
+func TestNot(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		parser     comb.Parser[bool]
+		input      string
+		wantErr    bool
+		wantOutput bool
+	}{
+		{
+			name:       "not matching parser should succeed",
+			input:      "123;",
+			parser:     cmb.Not(cmb.Alpha1()),
+			wantErr:    false,
+			wantOutput: true,
+		}, {
+			name:       "matching parser should fail",
+			input:      "abcd;",
+			parser:     cmb.Not(cmb.Alpha1()),
+			wantErr:    true,
+			wantOutput: false,
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc // this is needed for t.Parallel() to work correctly (or the same test case will be executed N times)
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotResult, gotErr := comb.RunOnString(tc.input, tc.parser)
+			if (gotErr != nil) != tc.wantErr {
+				t.Errorf("got error %v, want error: %t", gotErr, tc.wantErr)
+			}
+
+			if gotResult != tc.wantOutput {
+				t.Errorf("got output %t, want output %t", gotResult, tc.wantOutput)
+			}
+		})
+	}
+}
+
+func BenchmarkNot(b *testing.B) {
+	parser := cmb.Not(cmb.Alpha1())
+	input := comb.NewFromString("abcd;", 0)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = parser.Parse(input)
+	}
+}
+
+func TestStringUntil(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		parser     comb.Parser[string]
+		input      string
+		wantErr    bool
+		wantOutput string
+	}{
+		{
+			name:       "immediately matching parser should succeed",
+			input:      "abcd;",
+			parser:     cmb.StringUntil(cmb.Alpha1()),
+			wantErr:    false,
+			wantOutput: "",
+		}, {
+			name:       "non matching parser should fail",
+			input:      "123;",
+			parser:     cmb.StringUntil(cmb.Alpha1()),
+			wantErr:    true,
+			wantOutput: "",
+		}, {
+			name:       "matching parser should succeed",
+			input:      "123abcd;",
+			parser:     cmb.StringUntil(cmb.Alpha1()),
+			wantErr:    false,
+			wantOutput: "123",
+		}, {
+			name:       "empty input should fail",
+			input:      "",
+			parser:     cmb.StringUntil(cmb.Alpha1()),
+			wantErr:    true,
+			wantOutput: "",
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc // this is needed for t.Parallel() to work correctly (or the same test case will be executed N times)
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotResult, gotErr := comb.RunOnString(tc.input, tc.parser)
+			if (gotErr != nil) != tc.wantErr {
+				t.Errorf("got error %v, want error: %t", gotErr, tc.wantErr)
+			}
+
+			if gotResult != tc.wantOutput {
+				t.Errorf("got output %q, want output %q", gotResult, tc.wantOutput)
+			}
+		})
+	}
+}
+
+func BenchmarkStringUntil(b *testing.B) {
+	parser := cmb.Peek(cmb.Alpha1())
 	input := comb.NewFromString("abcd;", 0)
 
 	b.ResetTimer()
@@ -132,14 +246,13 @@ func TestAssign(t *testing.T) {
 		{
 			name:       "matching parser should succeed",
 			input:      "abcd",
-			parser:     Assign(1234, Alpha1()),
+			parser:     cmb.Assign(1234, cmb.Alpha1()),
 			wantErr:    false,
 			wantOutput: 1234,
-		},
-		{
+		}, {
 			name:       "non matching parser should fail",
 			input:      "123abcd;",
-			parser:     Assign(1234, Alpha1()),
+			parser:     cmb.Assign(1234, cmb.Alpha1()),
 			wantErr:    true,
 			wantOutput: 1234,
 		},
@@ -162,7 +275,7 @@ func TestAssign(t *testing.T) {
 }
 
 func BenchmarkAssign(b *testing.B) {
-	parser := Assign(1234, Alpha1())
+	parser := cmb.Assign(1234, cmb.Alpha1())
 	input := comb.NewFromString("abcd", 0)
 
 	b.ResetTimer()
@@ -184,31 +297,31 @@ func TestDelimited(t *testing.T) {
 		{
 			name:       "matching parser should succeed",
 			input:      "+1\r\n",
-			parser:     Delimited(Char('+'), Digit1(), CRLF()),
+			parser:     cmb.Delimited(cmb.Char('+'), cmb.Digit1(), cmb.CRLF()),
 			wantErr:    false,
 			wantOutput: "1",
 		}, {
 			name:       "no prefix match should fail",
 			input:      "1\r\n",
-			parser:     Delimited(Char('+'), comb.SafeSpot(Digit1()), CRLF()),
+			parser:     cmb.Delimited(cmb.Char('+'), comb.SafeSpot(cmb.Digit1()), cmb.CRLF()),
 			wantErr:    true,
 			wantOutput: "1",
 		}, {
 			name:       "no parser match should fail",
 			input:      "+\r\n",
-			parser:     Delimited(Char('+'), Digit1(), CRLF()),
+			parser:     cmb.Delimited(cmb.Char('+'), cmb.Digit1(), cmb.CRLF()),
 			wantErr:    true,
 			wantOutput: "",
 		}, {
 			name:       "no suffix match should fail",
 			input:      "+1",
-			parser:     Delimited(Char('+'), Digit1(), CRLF()),
+			parser:     cmb.Delimited(cmb.Char('+'), cmb.Digit1(), cmb.CRLF()),
 			wantErr:    true,
 			wantOutput: "1",
 		}, {
 			name:       "empty input should fail",
 			input:      "",
-			parser:     Delimited(Char('+'), Digit1(), CRLF()),
+			parser:     cmb.Delimited(cmb.Char('+'), cmb.Digit1(), cmb.CRLF()),
 			wantErr:    true,
 			wantOutput: "",
 		},
@@ -231,7 +344,7 @@ func TestDelimited(t *testing.T) {
 }
 
 func BenchmarkDelimited(b *testing.B) {
-	parser := Delimited(Char('+'), Digit1(), CRLF())
+	parser := cmb.Delimited(cmb.Char('+'), cmb.Digit1(), cmb.CRLF())
 	input := comb.NewFromString("+1\r\n", 0)
 
 	b.ResetTimer()
@@ -253,28 +366,25 @@ func TestPrefixed(t *testing.T) {
 		{
 			name:       "matching parser should succeed",
 			input:      "+123",
-			parser:     Prefixed(Char('+'), Digit1()),
+			parser:     cmb.Prefixed(cmb.Char('+'), cmb.Digit1()),
 			wantErr:    false,
 			wantOutput: "123",
-		},
-		{
+		}, {
 			name:       "no prefix match should fail",
 			input:      "+123",
-			parser:     Prefixed(Char('-'), Digit1()),
+			parser:     cmb.Prefixed(cmb.Char('-'), cmb.Digit1()),
 			wantErr:    true,
 			wantOutput: "",
-		},
-		{
+		}, {
 			name:       "no parser match should fail",
 			input:      "+",
-			parser:     Prefixed(Char('+'), Digit1()),
+			parser:     cmb.Prefixed(cmb.Char('+'), cmb.Digit1()),
 			wantErr:    true,
 			wantOutput: "",
-		},
-		{
+		}, {
 			name:       "empty input should fail",
 			input:      "",
-			parser:     Prefixed(Char('+'), Digit1()),
+			parser:     cmb.Prefixed(cmb.Char('+'), cmb.Digit1()),
 			wantErr:    true,
 			wantOutput: "",
 		},
@@ -297,7 +407,7 @@ func TestPrefixed(t *testing.T) {
 }
 
 func BenchmarkPrefixed(b *testing.B) {
-	parser := Prefixed(Char('+'), Digit1())
+	parser := cmb.Prefixed(cmb.Char('+'), cmb.Digit1())
 	input := comb.NewFromString("+123", 0)
 
 	b.ResetTimer()
@@ -319,28 +429,25 @@ func TestSuffixed(t *testing.T) {
 		{
 			name:       "matching parser should succeed",
 			input:      "1+23",
-			parser:     Suffixed(Digit1(), Char('+')),
+			parser:     cmb.Suffixed(cmb.Digit1(), cmb.Char('+')),
 			wantErr:    false,
 			wantOutput: "1",
-		},
-		{
+		}, {
 			name:       "no suffix match should fail",
 			input:      "1-23",
-			parser:     Suffixed(Digit1(), Char('+')),
+			parser:     cmb.Suffixed(cmb.Digit1(), cmb.Char('+')),
 			wantErr:    true,
 			wantOutput: "1",
-		},
-		{
+		}, {
 			name:       "no parser match should fail",
 			input:      "+",
-			parser:     Suffixed(Digit1(), Char('+')),
+			parser:     cmb.Suffixed(cmb.Digit1(), cmb.Char('+')),
 			wantErr:    true,
 			wantOutput: "",
-		},
-		{
+		}, {
 			name:       "empty input should fail",
 			input:      "",
-			parser:     Suffixed(Digit1(), Char('+')),
+			parser:     cmb.Suffixed(cmb.Digit1(), cmb.Char('+')),
 			wantErr:    true,
 			wantOutput: "",
 		},
@@ -363,7 +470,7 @@ func TestSuffixed(t *testing.T) {
 }
 
 func BenchmarkTerminated(b *testing.B) {
-	parser := Suffixed(Digit1(), Char('+'))
+	parser := cmb.Suffixed(cmb.Digit1(), cmb.Char('+'))
 	input := comb.NewFromString("123+", 0)
 
 	b.ResetTimer()
@@ -385,36 +492,33 @@ func TestMap(t *testing.T) {
 		{
 			name:  "matching parser should succeed",
 			input: "1abc\r\n",
-			parser: Map(Digit1(), func(digit string) (int, error) {
+			parser: cmb.Map(cmb.Digit1(), func(digit string) (int, error) {
 				i, _ := strconv.Atoi(digit)
 				return i, nil
 			}),
 			wantErr:    false,
 			wantOutput: 1,
-		},
-		{
+		}, {
 			name:  "failing parser should fail",
 			input: "abc\r\n",
-			parser: Map(Digit1(), func(digit string) (int, error) {
+			parser: cmb.Map(cmb.Digit1(), func(digit string) (int, error) {
 				i, _ := strconv.Atoi(digit)
 				return i, nil
 			}),
 			wantErr:    true,
 			wantOutput: 0,
-		},
-		{
+		}, {
 			name:  "failing mapper should fail",
 			input: "1abc\r\n",
-			parser: Map(Digit1(), func(digit string) (int, error) {
+			parser: cmb.Map(cmb.Digit1(), func(digit string) (int, error) {
 				return 0, errors.New("unexpected error")
 			}),
 			wantErr:    true,
 			wantOutput: 0,
-		},
-		{
+		}, {
 			name:  "empty input should fail",
 			input: "",
-			parser: Map(Digit1(), func(digit string) (int, error) {
+			parser: cmb.Map(cmb.Digit1(), func(digit string) (int, error) {
 				i, _ := strconv.Atoi(digit)
 				return i, nil
 			}),
@@ -440,7 +544,7 @@ func TestMap(t *testing.T) {
 }
 
 func BenchmarkMap(b *testing.B) {
-	parser := Map(Digit1(), func(digit string) (int, error) {
+	parser := cmb.Map(cmb.Digit1(), func(digit string) (int, error) {
 		i, _ := strconv.Atoi(digit)
 		return i, nil
 	})
@@ -470,7 +574,7 @@ func TestMap2(t *testing.T) {
 		{
 			name:  "matching parser should succeed",
 			input: "1abc\r\n",
-			parser: Map2(Digit1(), Alpha1(), func(digit string, alpha string) (TestStruct, error) {
+			parser: cmb.Map2(cmb.Digit1(), cmb.Alpha1(), func(digit string, alpha string) (TestStruct, error) {
 				left, _ := strconv.Atoi(digit)
 				return TestStruct{Foo: left, Bar: alpha}, nil
 			}),
@@ -479,7 +583,7 @@ func TestMap2(t *testing.T) {
 		}, {
 			name:  "failing parser should fail",
 			input: "abc\r\n",
-			parser: Map2(Digit1(), comb.SafeSpot(Alpha1()), func(digit string, alpha string) (TestStruct, error) {
+			parser: cmb.Map2(cmb.Digit1(), comb.SafeSpot(cmb.Alpha1()), func(digit string, alpha string) (TestStruct, error) {
 				left, _ := strconv.Atoi(digit)
 				return TestStruct{Foo: left, Bar: alpha}, nil
 			}),
@@ -488,7 +592,7 @@ func TestMap2(t *testing.T) {
 		}, {
 			name:  "failing mapper should fail",
 			input: "1abc\r\n",
-			parser: Map2(Digit1(), Alpha1(), func(digit string, alpha string) (TestStruct, error) {
+			parser: cmb.Map2(cmb.Digit1(), cmb.Alpha1(), func(digit string, alpha string) (TestStruct, error) {
 				return TestStruct{}, errors.New("unexpected error")
 			}),
 			wantErr:    true,
@@ -496,7 +600,7 @@ func TestMap2(t *testing.T) {
 		}, {
 			name:  "empty input should fail",
 			input: "",
-			parser: Map2(Digit1(), Alpha1(), func(digit string, alpha string) (TestStruct, error) {
+			parser: cmb.Map2(cmb.Digit1(), cmb.Alpha1(), func(digit string, alpha string) (TestStruct, error) {
 				left, _ := strconv.Atoi(digit)
 				return TestStruct{Foo: left, Bar: alpha}, nil
 			}),
@@ -527,7 +631,7 @@ func BenchmarkMap2(b *testing.B) {
 		Bar string
 	}
 
-	parser := Map2(Digit1(), Alpha1(), func(digit string, alpha string) (TestStruct, error) {
+	parser := cmb.Map2(cmb.Digit1(), cmb.Alpha1(), func(digit string, alpha string) (TestStruct, error) {
 		first, _ := strconv.Atoi(digit)
 		return TestStruct{Foo: first, Bar: alpha}, nil
 	})

--- a/cmb/combinators_test.go
+++ b/cmb/combinators_test.go
@@ -1,6 +1,7 @@
 package cmb_test
 
 import (
+	"bytes"
 	"errors"
 	"strconv"
 	"testing"
@@ -224,8 +225,72 @@ func TestStringUntil(t *testing.T) {
 }
 
 func BenchmarkStringUntil(b *testing.B) {
-	parser := cmb.Peek(cmb.Alpha1())
-	input := comb.NewFromString("abcd;", 0)
+	parser := cmb.StringUntil(cmb.Alpha1())
+	input := comb.NewFromString("1abcd;", 0)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = parser.Parse(input)
+	}
+}
+
+func TestBytesUntil(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		parser     comb.Parser[[]byte]
+		input      string
+		wantErr    bool
+		wantOutput []byte
+	}{
+		{
+			name:       "immediately matching parser should succeed",
+			input:      "abcd;",
+			parser:     cmb.BytesUntil(cmb.Alpha1()),
+			wantErr:    false,
+			wantOutput: []byte{},
+		}, {
+			name:       "non matching parser should fail",
+			input:      "123;",
+			parser:     cmb.BytesUntil(cmb.Alpha1()),
+			wantErr:    true,
+			wantOutput: []byte{},
+		}, {
+			name:       "matching parser should succeed",
+			input:      "123abcd;",
+			parser:     cmb.BytesUntil(cmb.Alpha1()),
+			wantErr:    false,
+			wantOutput: []byte{'1', '2', '3'},
+		}, {
+			name:       "empty input should fail",
+			input:      "",
+			parser:     cmb.BytesUntil(cmb.Alpha1()),
+			wantErr:    true,
+			wantOutput: []byte{},
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc // this is needed for t.Parallel() to work correctly (or the same test case will be executed N times)
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotOutput, gotErr := comb.RunOnBytes([]byte(tc.input), tc.parser)
+			if (gotErr != nil) != tc.wantErr {
+				t.Errorf("got error %v, want error: %t", gotErr, tc.wantErr)
+			}
+
+			t.Logf("got output: %#v", gotOutput)
+			if !bytes.Equal(gotOutput, tc.wantOutput) {
+				t.Errorf("got output %#v, want output %#v", gotOutput, tc.wantOutput)
+			}
+		})
+	}
+}
+
+func BenchmarkBytesUntil(b *testing.B) {
+	parser := cmb.BytesUntil(cmb.Alpha1())
+	input := comb.NewFromString("1abcd;", 0)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/cmb/expression_test.go
+++ b/cmb/expression_test.go
@@ -1,6 +1,7 @@
 package cmb_test
 
 import (
+	"math"
 	"slices"
 	"testing"
 
@@ -8,7 +9,7 @@ import (
 	"github.com/flowdev/comb/cmb"
 )
 
-func TestExpression_HappyPath(t *testing.T) {
+func TestExpression_IntHappyPath(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
@@ -317,7 +318,190 @@ func TestExpression_HappyPath(t *testing.T) {
 	}
 }
 
-func TestExpression_ErrorCases(t *testing.T) {
+func TestExpression_FloatHappyPath(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		parser        comb.Parser[float64]
+		input         string
+		wantOutput    float64
+		wantRemaining string
+	}{
+		{
+			name:          "just value",
+			parser:        cmb.Expression(cmb.Float64(false, 16, false)).Parser(),
+			input:         "12p3 ",
+			wantOutput:    0x12p3,
+			wantRemaining: " ",
+		}, {
+			name: "multi level infix ops",
+			parser: cmb.Expression(cmb.Float64(false, 10, false), cmb.InfixLevel([]cmb.InfixOp[float64]{
+				{
+					Op:       "*",
+					SafeSpot: true,
+					Fn: func(a, b float64) float64 {
+						return a * b
+					},
+				}, {
+					Op:       "/",
+					SafeSpot: true,
+					Fn: func(a, b float64) float64 {
+						return a / b
+					},
+				},
+			}), cmb.InfixLevel([]cmb.InfixOp[float64]{
+				{
+					Op:       "-",
+					SafeSpot: true,
+					Fn: func(a, b float64) float64 {
+						return a - b
+					},
+				}, {
+					Op:       "+",
+					SafeSpot: true,
+					Fn: func(a, b float64) float64 {
+						return a + b
+					},
+				},
+			})).Parser(),
+			input:         " \t 1 + 3 * \t 2 - 6 / 3 ag",
+			wantOutput:    5,
+			wantRemaining: " ag",
+		}, {
+			name: "parentheses and infix ops with strict floats",
+			parser: cmb.Expression(cmb.Float64(false, 10, true), cmb.InfixLevel([]cmb.InfixOp[float64]{
+				{
+					Op:       "*",
+					SafeSpot: true,
+					Fn: func(a, b float64) float64 {
+						return a * b
+					},
+				}, {
+					Op:       "/",
+					SafeSpot: true,
+					Fn: func(a, b float64) float64 {
+						return a / b
+					},
+				},
+			}), cmb.InfixLevel([]cmb.InfixOp[float64]{
+				{
+					Op:       "-",
+					SafeSpot: true,
+					Fn: func(a, b float64) float64 {
+						return a - b
+					},
+				}, {
+					Op:       "+",
+					SafeSpot: true,
+					Fn: func(a, b float64) float64 {
+						return a + b
+					},
+				},
+			})).AddParentheses("(", ")", true).Parser(),
+			input:         " \t( 1.0 + 3. ) * (\t 2. - 6.0 \t ) * .25",
+			wantOutput:    -4.0,
+			wantRemaining: "",
+		}, {
+			name: "all mixed up",
+			parser: cmb.Expression(cmb.Float64(false, 10, true)).AddPrefixLevel(cmb.PrefixOp[float64]{
+				Op:       "-",
+				SafeSpot: false,
+				Fn: func(i float64) float64 {
+					return -i
+				},
+			}).AddPostfixLevel(cmb.PostfixOp[float64]{
+				Op:       "--",
+				SafeSpot: false,
+				Fn: func(i float64) float64 {
+					return i - 1
+				},
+			}, cmb.PostfixOp[float64]{
+				Op:       "++",
+				SafeSpot: false,
+				Fn: func(i float64) float64 {
+					return i + 1
+				},
+			}).AddPrefixLevel(cmb.PrefixOp[float64]{
+				Op:       "!",
+				SafeSpot: false,
+				Fn: func(v float64) float64 {
+					r := float64(1)
+					for i := float64(1); i <= v; i++ {
+						r *= i
+					}
+					return r
+				},
+			}).AddInfixLevel(cmb.InfixOp[float64]{
+				Op:       "^",
+				SafeSpot: true,
+				Fn: func(a, b float64) float64 {
+					r := float64(1)
+					for i := float64(0); i < b; i++ {
+						r *= a
+					}
+					return r
+				},
+			}, cmb.InfixOp[float64]{
+				Op:       "%",
+				SafeSpot: true,
+				Fn: func(a, b float64) float64 {
+					return math.Remainder(a, b)
+				},
+			}).AddInfixLevel(cmb.InfixOp[float64]{
+				Op:       "*",
+				SafeSpot: true,
+				Fn: func(a, b float64) float64 {
+					return a * b
+				},
+			}, cmb.InfixOp[float64]{
+				Op:       "/",
+				SafeSpot: true,
+				Fn: func(a, b float64) float64 {
+					return a / b
+				},
+			}).AddInfixLevel(cmb.InfixOp[float64]{
+				Op:       "-",
+				SafeSpot: true,
+				Fn: func(a, b float64) float64 {
+					return a - b
+				},
+			}, cmb.InfixOp[float64]{
+				Op:       "+",
+				SafeSpot: true,
+				Fn: func(a, b float64) float64 {
+					return a + b
+				},
+			}).AddParentheses("(", ")", true).AddParentheses("[", "]", true).Parser(),
+			input:         "-  (\t ! 2. \t ++ + 3.0 --) * \t [ 2.0 ^ 2. - 12.000 % 6. ] / 4.0",
+			wantOutput:    -8,
+			wantRemaining: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc // this is needed for t.Parallel() to work correctly (or the same test case will be executed N times)
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			newState, gotOutput, gotErr := tc.parser.Parse(comb.NewFromString(tc.input, 10))
+			if gotErr != nil {
+				t.Errorf("found error %v", gotErr)
+			}
+
+			if gotOutput != tc.wantOutput {
+				t.Errorf("got output %f, want output %f", gotOutput, tc.wantOutput)
+			}
+
+			gotRemaining := newState.CurrentString()
+			if gotRemaining != tc.wantRemaining {
+				t.Errorf("got remaining %q, want remaining %q", gotRemaining, tc.wantRemaining)
+			}
+		})
+	}
+}
+
+func TestExpression_IntErrorCases(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
@@ -329,9 +513,9 @@ func TestExpression_ErrorCases(t *testing.T) {
 	}{
 		{
 			name:       "additional character before value",
-			parser:     cmb.Count(1, cmb.Expression(comb.SafeSpot(cmb.Int64(false, 10))).Parser()),
-			input:      "] 123",
-			wantOutput: []int64{123},
+			parser:     cmb.Count(1, cmb.Expression(comb.SafeSpot(cmb.Int64(true, 10))).Parser()),
+			input:      "] -123",
+			wantOutput: []int64{-123},
 			wantErrors: 1,
 		}, {
 			name: "prefix op",
@@ -700,6 +884,174 @@ func TestExpression_ErrorCases(t *testing.T) {
 				})).AddParentheses("(", ")", true).AddParentheses("[", "]", true).Parser()),
 			input:      " \\ - | ( ? ! ~ 2 ` ++ ' + ; 3 : -- . ) , * @ [ # 2 $ ++ ++ ^ & 2 { - } 12 < ++ % > 6 a ] b ++ ++ ++ ++ / c 4 d +( 3 )",
 			wantOutput: []int64{2, 1, 3, -1, 0, 2, 4, -12, 1, 0, 1, 3},
+			wantErrors: 22,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc // this is needed for t.Parallel() to work correctly (or the same test case will be executed N times)
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotOutput, err := comb.RunOnState(comb.NewFromString(tc.input, 50), comb.NewPreparedParser(tc.parser))
+			t.Logf("got error(s) %v", err)
+			if slices.Compare(gotOutput, tc.wantOutput) != 0 {
+				t.Errorf("got output %#v, want output %#v", gotOutput, tc.wantOutput)
+			}
+			if got, want := len(comb.UnwrapErrors(err)), tc.wantErrors; got != want {
+				t.Errorf("err=%v, want errors=%d", err, want)
+			}
+		})
+	}
+}
+
+func TestExpression_FloatErrorCases(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		parser     comb.Parser[[]float64]
+		input      string
+		wantOutput []float64
+		wantErrors int
+	}{
+		{
+			name:       "additional character before value",
+			parser:     cmb.Count(1, cmb.Expression(comb.SafeSpot(cmb.Float64(true, 10, false))).Parser()),
+			input:      "] -123",
+			wantOutput: []float64{-123},
+			wantErrors: 1,
+		}, {
+			name:       "integer as strict float value",
+			parser:     cmb.Count(1, cmb.Expression(comb.SafeSpot(cmb.Float64(false, 10, true))).Parser()),
+			input:      "123 125.",
+			wantOutput: []float64{125.0},
+			wantErrors: 1,
+		}, {
+			name: "prefix op",
+			parser: cmb.Count(1, cmb.Expression(comb.SafeSpot(cmb.Float64(false, 10, false)),
+				cmb.PrefixLevel([]cmb.PrefixOp[float64]{
+					{
+						Op:       "-",
+						SafeSpot: true,
+						Fn: func(i float64) float64 {
+							return -i
+						},
+					},
+				})).Parser()),
+			input:      "! - | .123",
+			wantOutput: []float64{-.123},
+			wantErrors: 2,
+		}, {
+			name: "infix op",
+			parser: cmb.Count(2, cmb.Expression(comb.SafeSpot(cmb.Float64(false, 10, true)),
+				cmb.InfixLevel([]cmb.InfixOp[float64]{
+					{
+						Op:       "+",
+						SafeSpot: true,
+						Fn: func(a, b float64) float64 {
+							return a + b
+						},
+					},
+				})).Parser()),
+			input:      "(12e3)+ 4e- 456.",
+			wantOutput: []float64{12e3, 456.},
+			wantErrors: 3,
+		}, {
+			name: "all mixed up",
+			parser: cmb.Count(12, cmb.Expression(comb.SafeSpot(cmb.Float64(false, 10, false)),
+				cmb.PrefixLevel([]cmb.PrefixOp[float64]{
+					{
+						Op:       "-",
+						SafeSpot: true,
+						Fn: func(i float64) float64 {
+							return -i
+						},
+					},
+				}), cmb.PostfixLevel([]cmb.PostfixOp[float64]{
+					{
+						Op:       "--",
+						SafeSpot: true,
+						Fn: func(i float64) float64 {
+							return i - 1
+						},
+					}, {
+						Op:       "++",
+						SafeSpot: true,
+						Fn: func(i float64) float64 {
+							return i + 1
+						},
+					},
+				}), cmb.PrefixLevel([]cmb.PrefixOp[float64]{
+					{
+						Op:       "!",
+						SafeSpot: true,
+						Fn: func(v float64) float64 {
+							r := float64(1)
+							for i := float64(1); i <= v; i++ {
+								r *= i
+							}
+							return r
+						},
+					},
+				}), cmb.InfixLevel([]cmb.InfixOp[float64]{
+					{
+						Op:       "^",
+						SafeSpot: true,
+						Fn: func(a, b float64) float64 {
+							r := float64(1)
+							for i := float64(0); i < b; i++ {
+								r *= a
+							}
+							return r
+						},
+					}, {
+						Op:       "%",
+						SafeSpot: true,
+						Fn: func(a, b float64) float64 {
+							if b == 0 {
+								return 0
+							}
+							return math.Remainder(a, b)
+						},
+					},
+				}), cmb.InfixLevel([]cmb.InfixOp[float64]{
+					{
+						Op:       "*",
+						SafeSpot: true,
+						Fn: func(a, b float64) float64 {
+							return a * b
+						},
+					}, {
+						Op:       "/",
+						SafeSpot: true,
+						Fn: func(a, b float64) float64 {
+							if b == 0 {
+								if a >= 0 {
+									return 99999
+								}
+								return -99999
+							}
+							return a / b
+						},
+					},
+				}), cmb.InfixLevel([]cmb.InfixOp[float64]{
+					{
+						Op:       "-",
+						SafeSpot: true,
+						Fn: func(a, b float64) float64 {
+							return a - b
+						},
+					}, {
+						Op:       "+",
+						SafeSpot: true,
+						Fn: func(a, b float64) float64 {
+							return a + b
+						},
+					},
+				})).AddParentheses("(", ")", true).AddParentheses("[", "]", true).Parser()),
+			input:      " \\ - | ( ? ! ~ 2 ` ++ ' + ; 3 : -- . ) , * @ [ # 2 $ ++ ++ ^ & 2 { - } 12 < ++ % > 6 a ] b ++ ++ ++ ++ / c 4 d +( 3 )",
+			wantOutput: []float64{2, 1, 3, -1, 0, 2, 4, -12, 1, 0, 1, 3},
 			wantErrors: 22,
 		},
 	}

--- a/cmb/first_successful.go
+++ b/cmb/first_successful.go
@@ -1,6 +1,8 @@
 package cmb
 
 import (
+	"slices"
+
 	"github.com/flowdev/comb"
 )
 
@@ -115,10 +117,7 @@ func (fsd *firstSuccessfulData[Output]) parseAfterChild(
 }
 
 func (fsd *firstSuccessfulData[Output]) indexForID(id int32) int {
-	for i, p := range fsd.parsers {
-		if p.ID() == id {
-			return i
-		}
-	}
-	return -1
+	return slices.IndexFunc(fsd.parsers, func(p comb.Parser[Output]) bool {
+		return p.ID() == id
+	})
 }

--- a/cmb/first_successful_test.go
+++ b/cmb/first_successful_test.go
@@ -22,22 +22,19 @@ func TestFirstSuccessful(t *testing.T) {
 			parser:     FirstSuccessful(Digit1(), Alpha0()),
 			wantErr:    false,
 			wantOutput: "123",
-		},
-		{
+		}, {
 			name:       "tail matching parser should succeed",
 			input:      "abc",
 			parser:     FirstSuccessful(Digit1(), Alpha0()),
 			wantErr:    false,
 			wantOutput: "abc",
-		},
-		{
+		}, {
 			name:       "no matching parser should fail",
 			input:      "$%^*",
 			parser:     FirstSuccessful(Digit1(), Alpha1()),
 			wantErr:    true,
 			wantOutput: "",
-		},
-		{
+		}, {
 			name:       "empty input should fail",
 			input:      "",
 			parser:     FirstSuccessful(Digit1(), Alpha1()),

--- a/cmb/multi.go
+++ b/cmb/multi.go
@@ -18,12 +18,12 @@ func Count[Output any](count int, parse comb.Parser[Output]) comb.Parser[[]Outpu
 	return ManyMN(parse, count, count)
 }
 
-// Many0 applies a parser repeatedly until it fails, and returns a slice of all
+// Many0 applies a parser repeatedly until it fails and returns a slice of all
 // the results as the Result's Output.
 //
-// Note that Many0 will succeed even if the parser fails to match at all. It will
-// however fail if the provided parser accepts empty inputs (such as `Digit0`, or
-// `Alpha0`) in order to prevent infinite loops.
+// Note that Many0 will succeed even if the parser fails to match at all. It will,
+// however, fail if the provided parser accepts empty inputs (such as `Digit0`, or
+// `Alpha0`) to prevent infinite loops.
 func Many0[Output any](parse comb.Parser[Output]) comb.Parser[[]Output] {
 	return ManyMN(parse, 0, math.MaxInt)
 }
@@ -33,7 +33,7 @@ func Many0[Output any](parse comb.Parser[Output]) comb.Parser[[]Output] {
 // match at least once.
 //
 // Note that Many1 will fail if the provided parser accepts empty
-// inputs (such as `Digit0`, or `Alpha0`) in order to prevent infinite loops.
+// inputs (such as `Digit0`, or `Alpha0`) to prevent infinite loops.
 func Many1[Output any](parse comb.Parser[Output]) comb.Parser[[]Output] {
 	return ManyMN(parse, 1, math.MaxInt)
 }
@@ -42,12 +42,12 @@ func Many1[Output any](parse comb.Parser[Output]) comb.Parser[[]Output] {
 // the results as the Result's Output.
 //
 // Note that ManyMN fails if the provided parser accepts empty inputs (such as
-// `Digit0`, or `Alpha0`) in order to prevent infinite loops.
+// `Digit0`, or `Alpha0`) to prevent infinite loops.
 func ManyMN[Output any](parse comb.Parser[Output], atLeast, atMost int) comb.Parser[[]Output] {
 	return SeparatedMN[Output, string](parse, nil, atLeast, atMost, false)
 }
 
-// Separated0 applies an element parser and a separator parser repeatedly in order
+// Separated0 applies an element parser and a separator parser repeatedly
 // to produce a list of elements.
 //
 // Note that Separated0 will succeed even if the element parser fails to match at all.
@@ -56,16 +56,16 @@ func ManyMN[Output any](parse comb.Parser[Output], atLeast, atMost int) comb.Par
 // from the provided main parser, it will succeed even if the separator parser fails to
 // match at all.
 //
-// The parser will fail if the both parsers together accepted an empty input
-// in order to prevent infinite loops.
-func Separated0[Output any, S comb.Separator](
+// The parser will fail if both parsers together accepted an empty input
+// to prevent infinite loops.
+func Separated0[Output any, S any](
 	parse comb.Parser[Output], separator comb.Parser[S],
 	parseSeparatorAtEnd bool,
 ) comb.Parser[[]Output] {
 	return SeparatedMN(parse, separator, 0, math.MaxInt, parseSeparatorAtEnd)
 }
 
-// Separated1 applies an element parser and a separator parser repeatedly in order
+// Separated1 applies an element parser and a separator parser repeatedly
 // to produce a list of elements.
 //
 // Note that Separated1 will fail if the element parser fails to match at all.
@@ -73,7 +73,10 @@ func Separated0[Output any, S comb.Separator](
 // Because the `SeparatedList1` is really looking to produce a list of elements resulting
 // from the provided main parser, it will succeed even if the separator parser fails to
 // match at all.
-func Separated1[Output any, S comb.Separator](
+//
+// The parser will fail if both parsers together accepted an empty input
+// to prevent infinite loops.
+func Separated1[Output any, S any](
 	parse comb.Parser[Output], separator comb.Parser[S],
 	parseSeparatorAtEnd bool,
 ) comb.Parser[[]Output] {

--- a/cmb/numbers.go
+++ b/cmb/numbers.go
@@ -207,7 +207,8 @@ func UInt64(signAllowed bool, base int) comb.Parser[uint64] {
 // `underscoreAllowed` can be true to allow '_' characters.
 // No check on position or number of (consecutive) underscores is done.
 // The Go parse functions will do more checks on this.
-func Float(signAllowed bool, base int, underscoreAllowed bool) comb.Parser[string] {
+// `strict` can be true to disallow integer values (the number HAS to contain a decimal point or an exponent).
+func Float(signAllowed bool, base int, underscoreAllowed, strict bool) comb.Parser[string] {
 	if base != 0 && base != 10 && base != 16 {
 		panic(fmt.Sprintf("The base has to be 0, 10 or 16, but is: %d", base))
 	}
@@ -230,8 +231,10 @@ func Float(signAllowed bool, base int, underscoreAllowed bool) comb.Parser[strin
 		}
 
 		n := 0 // number of bytes read from input
+		hasPoint := false
+		hasExponent := false
 
-		// Pick off the leading sign.
+		// pick off the leading sign
 		if signAllowed {
 			if input[0] == '+' || input[0] == '-' {
 				n = 1
@@ -250,7 +253,7 @@ func Float(signAllowed bool, base int, underscoreAllowed bool) comb.Parser[strin
 
 		digit, m, good = readDigits(input[n:], underscoreAllowed, digits)
 		if !good && digit != '.' {
-			return state, "", state.NewSyntaxError("%s found '%c'", expected, digit)
+			return state, "", state.MoveBy(n).NewSyntaxError("%s found '%c'", expected, digit)
 		}
 		n += m
 		hasDigits := good
@@ -259,22 +262,28 @@ func Float(signAllowed bool, base int, underscoreAllowed bool) comb.Parser[strin
 			n++
 			digit, m, good = readDigits(input[n:], underscoreAllowed, digits)
 			if !good && !hasDigits {
-				return state, "", state.NewSyntaxError("%s found '%c'", expected, digit)
+				return state, "", state.MoveBy(n).NewSyntaxError("%s found '%c'", expected, digit)
 			}
 			n += m
+			hasPoint = true
 		}
 
-		if (base == 10 && (digit == 'e' || digit == 'E')) ||
-			(base == 16 && (digit == 'p' || digit == 'P')) {
-
+		if isExponent(digit, base) {
 			n++
+			if len(input) > n && (input[n] == '-' || input[n] == '+') {
+				n++
+			}
 			digit, m, good = readDigits(input[n:], underscoreAllowed, allDigits[:10])
 			if !good {
-				return state, "", state.NewSyntaxError("%s found '%c'", expected, digit)
+				return state, "", state.MoveBy(n).NewSyntaxError("%s found '%c'", expected, digit)
 			}
 			n += m
+			hasExponent = true
 		}
 
+		if strict && !hasPoint && !hasExponent {
+			return state, "", state.NewSyntaxError("%s (no decimal point or exponent found)", expected)
+		}
 		return state.MoveBy(n), input[:n], nil
 	}
 
@@ -282,7 +291,11 @@ func Float(signAllowed bool, base int, underscoreAllowed bool) comb.Parser[strin
 	if base == 0 {
 		recovererBase = 10 // best guess
 	}
-	return comb.NewParser[string](expected, parser, indexOfFloat(allDigits[:recovererBase], signAllowed))
+	return comb.NewParser[string](
+		expected,
+		parser,
+		indexOfFloat(signAllowed, allDigits[:recovererBase], underscoreAllowed, strict),
+	)
 }
 func rebaseFloat(input string, base int) (int, int) {
 	if base != 0 {
@@ -319,35 +332,66 @@ ForLoop:
 	}
 	return digit, n, good
 }
-
-func indexOfFloat(digits string, signAllowed bool) func(comb.State, interface{}) (int, interface{}) {
+func indexOfFloat(signAllowed bool, digits string, underscoreAllowed, strict bool) func(comb.State, interface{}) (int, interface{}) {
 	return func(state comb.State, data interface{}) (int, interface{}) {
-		input := state.CurrentString()
-		i := strings.IndexAny(input, digits)
-		if i < 0 {
-			return comb.RecoverWasteTooMuch, nil
+		orgInput := state.CurrentString()
+		input := orgInput
+		i := 0
+		j := -1
+		isStrict := false
+		for (j < 0) || (strict && !isStrict) {
+			j = strings.IndexAny(input, digits)
+			if j < 0 {
+				return comb.RecoverWasteTooMuch, nil
+			}
+			if j > 0 && (input[j-1] == '.') {
+				j--
+				isStrict = true
+			} else if strict {
+				char, n, _ := readDigits(input[j+1:], underscoreAllowed, digits)
+				if char == '.' {
+					isStrict = true
+				} else if isExponent(char, len(digits)) && len(input) > j+1+n+1 {
+					c1 := rune(input[j+1+n+1])
+					c2 := ' '
+					if len(input) > j+1+n+2 {
+						c2 = rune(input[j+1+n+2])
+					}
+					if strings.ContainsRune(digits, c1) || ((c1 == '-' || c1 == '+') && strings.ContainsRune(digits, c2)) {
+						isStrict = true
+					} else {
+						j += n + 2 // start the next search after digits and char
+					}
+				} else {
+					j += n + 1 // start the next search after digits
+				}
+			}
+			i += j
+			input = orgInput[i:]
 		}
-		if i > 0 && (input[i-1] == '.') {
-			i--
-		}
-		if signAllowed && i > 0 && (input[i-1] == '-' || input[i-1] == '+') {
+		if signAllowed && i > 0 && (orgInput[i-1] == '-' || orgInput[i-1] == '+') {
 			i--
 		}
 		return i, nil
 	}
 }
+func isExponent(char rune, base int) bool {
+	if base < 14 {
+		return char == 'e' || char == 'E'
+	}
+	return char == 'p' || char == 'P'
+}
 
 // Float64 parses a floating point number from the input using `strconv.ParseFloat`.
-func Float64(signAllowed bool, base int) comb.Parser[float64] {
+func Float64(signAllowed bool, base int, strict bool) comb.Parser[float64] {
 	underscoreAllowed := false
 	if base == 0 {
 		underscoreAllowed = true
 	}
-	floatParser := Float(signAllowed, base, underscoreAllowed)
+	floatParser := Float(signAllowed, base, underscoreAllowed, strict)
 
 	parser := func(state comb.State) (comb.State, float64, *comb.ParserError) {
-		nState, out, pErr := floatParser.ParseAny(0, state)
-		str, _ := out.(string)
+		nState, str, pErr := floatParser.Parse(state)
 		if pErr != nil {
 			return state, 0, comb.ClaimError(pErr)
 		}
@@ -361,7 +405,7 @@ func Float64(signAllowed bool, base int) comb.Parser[float64] {
 		}
 		f, err := strconv.ParseFloat(str, 64)
 		if err != nil {
-			return nState, f, state.NewSemanticError(err.Error())
+			return state, f, state.NewSemanticError(err.Error())
 		}
 		return nState, f, nil
 	}

--- a/cmb/numbers_test.go
+++ b/cmb/numbers_test.go
@@ -62,11 +62,32 @@ func TestInt64(t *testing.T) {
 			wantOutput:    -0o171,
 			wantRemaining: "",
 		}, {
+			name:          "parsing binary integer should succeed",
+			parser:        cmb.Int64(true, 2),
+			input:         "-10",
+			wantErr:       false,
+			wantOutput:    -2,
+			wantRemaining: "",
+		}, {
+			name:          "parsing octal integer should succeed",
+			parser:        cmb.Int64(true, 8),
+			input:         "+13",
+			wantErr:       false,
+			wantOutput:    11,
+			wantRemaining: "",
+		}, {
 			name:          "parsing hex integer should succeed",
 			parser:        cmb.Int64(true, 16),
 			input:         "+1f",
 			wantErr:       false,
 			wantOutput:    31,
+			wantRemaining: "",
+		}, {
+			name:          "parsing integer of base 20 should succeed",
+			parser:        cmb.Int64(true, 20),
+			input:         "+1j",
+			wantErr:       false,
+			wantOutput:    39,
 			wantRemaining: "",
 		}, {
 			name:          "parsing overflowing integer should fail",
@@ -207,60 +228,88 @@ func TestFloat64(t *testing.T) {
 	}{
 		{
 			name:          "parsing positive float should succeed",
-			parser:        cmb.Float64(false, 10),
+			parser:        cmb.Float64(false, 10, true),
 			input:         "12.3",
 			wantErr:       false,
 			wantOutput:    12.3,
 			wantRemaining: "",
 		}, {
 			name:          "parsing negative float should succeed",
-			parser:        cmb.Float64(true, 10),
+			parser:        cmb.Float64(true, 10, true),
 			input:         "-.123",
 			wantErr:       false,
 			wantOutput:    -.123,
 			wantRemaining: "",
 		}, {
+			name:          "parsing integer in non-strict mode should succeed",
+			parser:        cmb.Float64(false, 10, false),
+			input:         "123_",
+			wantErr:       false,
+			wantOutput:    123.0,
+			wantRemaining: "_",
+		}, {
+			name:          "parsing integer in strict mode should fail",
+			parser:        cmb.Float64(false, 10, true),
+			input:         "123",
+			wantErr:       true,
+			wantOutput:    0.0,
+			wantRemaining: "123",
+		}, {
 			name:          "parsing positive float prefix should succeed",
-			parser:        cmb.Float64(false, 0),
+			parser:        cmb.Float64(false, 0, true),
 			input:         "0x1_2.p3abc",
 			wantErr:       false,
 			wantOutput:    0x1_2.p3,
 			wantRemaining: "abc",
 		}, {
 			name:          "parsing negative float prefix should succeed",
-			parser:        cmb.Float64(true, 0),
+			parser:        cmb.Float64(true, 0, true),
 			input:         "-1.2_3e4abc",
 			wantErr:       false,
 			wantOutput:    -1.2_3e4,
 			wantRemaining: "abc",
 		}, {
 			name:          "parsing wild hex float should succeed",
-			parser:        cmb.Float64(true, 16),
+			parser:        cmb.Float64(true, 16, true),
 			input:         "-.2p3",
 			wantErr:       false,
 			wantOutput:    -0x.2p3,
 			wantRemaining: "",
 		}, {
 			name:          "parsing wilder hex float should succeed",
-			parser:        cmb.Float64(true, 0),
+			parser:        cmb.Float64(true, 0, true),
 			input:         "-0x.2p3",
 			wantErr:       false,
 			wantOutput:    -0x.2p3,
 			wantRemaining: "",
 		}, {
 			name:          "parsing overflowing float should fail",
-			parser:        cmb.Float64(true, 10),
-			input:         "1.79769313486231570814527423731704356798071e+308", // max float64 + very little
+			parser:        cmb.Float64(true, 10, false),
+			input:         "1.79769313486231589999999999999999999999999e+308", // max float64 + a little
 			wantErr:       true,
-			wantOutput:    0.0,
-			wantRemaining: "1.79769313486231570814527423731704356798071e+308",
+			wantOutput:    math.Inf(1),
+			wantRemaining: "1.79769313486231589999999999999999999999999e+308",
 		}, {
 			name:          "parsing float with invalid leading sign should fail",
-			parser:        cmb.Float64(true, 10),
+			parser:        cmb.Float64(true, 10, false),
 			input:         "!1.27",
 			wantErr:       true,
 			wantOutput:    0,
 			wantRemaining: "!1.27",
+		}, {
+			name:          "sign only should fail",
+			parser:        cmb.Float64(true, 10, false),
+			input:         "-",
+			wantErr:       true,
+			wantOutput:    0,
+			wantRemaining: "-",
+		}, {
+			name:          "empty input should fail",
+			parser:        cmb.Float64(true, 10, false),
+			input:         "",
+			wantErr:       true,
+			wantOutput:    0,
+			wantRemaining: "",
 		},
 	}
 
@@ -270,6 +319,7 @@ func TestFloat64(t *testing.T) {
 			t.Parallel()
 
 			newState, gotResult, gotErr := tc.parser.Parse(comb.NewFromString(tc.input, 10))
+			t.Logf("got error: %v", gotErr)
 			if (gotErr != nil) != tc.wantErr {
 				t.Errorf("got error %v, want error: %t", gotErr, tc.wantErr)
 			}
@@ -287,7 +337,7 @@ func TestFloat64(t *testing.T) {
 }
 
 func BenchmarkFloat64(b *testing.B) {
-	parser := cmb.Float64(false, 10)
+	parser := cmb.Float64(false, 10, true)
 	input := comb.NewFromString("1.23", 0)
 
 	b.ResetTimer()

--- a/cmb/separatedmn.go
+++ b/cmb/separatedmn.go
@@ -4,7 +4,7 @@ import (
 	"github.com/flowdev/comb"
 )
 
-// SeparatedMN applies an element parser and a separator parser repeatedly in order
+// SeparatedMN applies an element parser and a separator parser repeatedly
 // to produce a slice of elements.
 //
 // Because SeparatedMN is really looking to produce a list of elements resulting
@@ -15,7 +15,7 @@ import (
 //
 // The parser will fail if both parsers together accepted an empty input
 // to prevent infinite loops.
-func SeparatedMN[Output any, S comb.Separator](
+func SeparatedMN[Output any, S any](
 	parser comb.Parser[Output], separator comb.Parser[S],
 	atLeast, atMost int,
 	parseSeparatorAtEnd bool,
@@ -43,7 +43,7 @@ func SeparatedMN[Output any, S comb.Separator](
 	return p
 }
 
-type separatedData[Output any, S comb.Separator] struct {
+type separatedData[Output any, S any] struct {
 	id                  func() int32
 	parser              comb.Parser[Output]
 	separator           comb.Parser[S]

--- a/cmb/sequence.go
+++ b/cmb/sequence.go
@@ -1,0 +1,95 @@
+package cmb
+
+import (
+	"slices"
+
+	"github.com/flowdev/comb"
+)
+
+// Sequence uses a list of parsers in order, one by one,
+// until one fails, or they are all successful.
+// The output of all successful parsers is returned as output.
+// All parsers have to be of the same type.
+//
+// If any parser fails, this combinator produces an error result.
+func Sequence[Output any](parsers ...comb.Parser[Output]) comb.Parser[[]Output] {
+	if len(parsers) == 0 {
+		panic("Sequence(missing parsers)")
+	}
+
+	fsd := &sequenceData[Output]{parsers: parsers}
+
+	p := comb.NewBranchParser[[]Output]("Sequence", fsd.children, fsd.parseAfterChild)
+	fsd.id = p.ID
+	return p
+}
+
+type sequenceData[Output any] struct {
+	id      func() int32
+	parsers []comb.Parser[Output]
+}
+
+// partialSeqResult is internal to the parsing method and methods and functions called by it.
+type partialSeqResult[Output any] struct {
+	outs []Output
+}
+
+func (sd *sequenceData[Output]) children() []comb.AnyParser {
+	children := make([]comb.AnyParser, len(sd.parsers))
+	for i, p := range sd.parsers {
+		children[i] = p
+	}
+	return children
+}
+
+func (sd *sequenceData[Output]) parseAfterChild(
+	childID int32,
+	childStartState, childState comb.State,
+	childOut interface{},
+	childErr *comb.ParserError,
+	data interface{},
+) (comb.State, []Output, *comb.ParserError, interface{}) {
+	var res partialSeqResult[Output]
+	var out Output
+	idx := 0
+
+	comb.Debugf("Sequence.parseAfterChild - childID=%d, pos=%d", childID, childState.CurrentPos())
+
+	if childID >= 0 { // on the way up: Fetch
+		res, _ = data.(partialSeqResult[Output])
+		out, _ = childOut.(Output)
+		idx = sd.indexForID(childID)
+		if idx < 0 {
+			childErr = childState.NewSemanticError("parsing after child with unknown ID %d", childID)
+			childState = childState.SaveError(childErr)
+			idx = -1 // will be incremented before usage
+		} else {
+			res.outs[idx] = out
+		}
+
+		if childErr != nil {
+			return childState, res.outs, childErr, res
+		}
+		idx++
+	} else {
+		res.outs = make([]Output, len(sd.parsers))
+	}
+
+	for i := idx; i < len(sd.parsers); i++ {
+		p := sd.parsers[i]
+		childStartState = childState
+		childState, childOut, childErr = p.ParseAny(sd.id(), childStartState)
+		out, _ = childOut.(Output)
+		res.outs[i] = out
+		if childErr != nil {
+			return childState, res.outs, childErr, res
+		}
+	}
+	return childState, res.outs, nil, nil
+}
+
+func (sd *sequenceData[Output]) indexForID(id int32) int {
+	return slices.IndexFunc(sd.parsers, func(p comb.Parser[Output]) bool {
+		return p.ID() == id
+	})
+}

--- a/cmb/sequence_test.go
+++ b/cmb/sequence_test.go
@@ -1,0 +1,77 @@
+package cmb
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/flowdev/comb"
+)
+
+func TestSequence(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		input      string
+		parser     comb.Parser[[]string]
+		wantErr    bool
+		wantOutput []string
+	}{
+		{
+			name:       "matching parsers should succeed",
+			input:      "123abc",
+			parser:     Sequence(Digit1(), Alpha1()),
+			wantErr:    false,
+			wantOutput: []string{"123", "abc"},
+		}, {
+			name:       "head matching parser should fail",
+			input:      "123;",
+			parser:     Sequence(Digit1(), Alpha1()),
+			wantErr:    true,
+			wantOutput: []string{"123", ""},
+		}, {
+			name:       "tail matching parser should fail",
+			input:      "abc",
+			parser:     Sequence(comb.SafeSpot(Digit1()), comb.SafeSpot(Alpha1())),
+			wantErr:    true,
+			wantOutput: []string{"", "abc"},
+		}, {
+			name:       "no matching parser should fail",
+			input:      "$%^*",
+			parser:     Sequence(Digit1(), Alpha1()),
+			wantErr:    true,
+			wantOutput: []string{"", ""},
+		}, {
+			name:       "empty input should fail",
+			input:      "",
+			parser:     Sequence(Digit1(), Alpha1()),
+			wantErr:    true,
+			wantOutput: []string{"", ""},
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc // this is needed for t.Parallel() to work correctly (or the same test case will be executed N times)
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotOutput, gotErr := comb.RunOnString(tc.input, tc.parser)
+			if (gotErr != nil) != tc.wantErr {
+				t.Errorf("got error %v, want error: %t", gotErr, tc.wantErr)
+			}
+
+			if !slices.Equal(gotOutput, tc.wantOutput) {
+				t.Errorf("got output %q, want %q", gotOutput, tc.wantOutput)
+			}
+		})
+	}
+}
+
+func BenchmarkSequence(b *testing.B) {
+	p := Sequence(Char('a'), Char('b'))
+	input := comb.NewFromString("abc", 0)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _, _ = p.Parse(input)
+	}
+}

--- a/examples/redis/redis.go
+++ b/examples/redis/redis.go
@@ -123,7 +123,7 @@ func SimpleString() comb.Parser[RESPMessage] {
 
 	return cmb.Prefixed(
 		S(string(SimpleStringKind)),
-		cmb.Map(cmb.UntilString("\r\n"), mapFn),
+		cmb.Map(cmb.StringUntil(cmb.String("\r\n")), mapFn),
 	)
 }
 
@@ -159,7 +159,7 @@ func Error() comb.Parser[RESPMessage] {
 
 	return cmb.Prefixed(
 		S(string(ErrorKind)),
-		cmb.Map(cmb.UntilString("\r\n"), mapFn),
+		cmb.Map(cmb.StringUntil(cmb.String("\r\n")), mapFn),
 	)
 }
 
@@ -195,7 +195,7 @@ func Integer() comb.Parser[RESPMessage] {
 
 	return cmb.Prefixed(
 		S(string(IntegerKind)),
-		cmb.Map(cmb.UntilString("\r\n"), mapFn),
+		cmb.Map(cmb.StringUntil(cmb.String("\r\n")), mapFn),
 	)
 }
 
@@ -249,7 +249,7 @@ func BulkString() comb.Parser[RESPMessage] {
 	return cmb.Map2(
 		sizePrefix(S(string(BulkStringKind))),
 		cmb.Optional(
-			cmb.UntilString("\r\n"),
+			cmb.StringUntil(cmb.String("\r\n")),
 		),
 		mapFn,
 	)

--- a/experiments/parsify/parser.go
+++ b/experiments/parsify/parser.go
@@ -1,10 +1,12 @@
 package parsify
 
 import (
-	"github.com/flowdev/comb"
+	"fmt"
 	"strconv"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/flowdev/comb"
 )
 
 // Delimited parses and discards the result from the prefix parser, then
@@ -94,6 +96,50 @@ func Char2[Output rune](char rune) Parser[Output] {
 
 		return state.MoveBy(size), Output(r), nil
 	}
+}
+
+// CMBUntilString parses until it finds a token in the input and returns
+// the part of the input that preceded the token.
+// If found, the parser moves beyond the stop string.
+// If the token could not be found, the parser returns an error result.
+//
+// NOTE:
+//   - This function panics if `stop` is empty.
+//   - CMBUntilString is rather dangerous especially in case of error recovery
+//     because it potentially consumes much more input than expected.
+//     In error cases it will usually start earlier because other parsers are skipped.
+//     Especially using it as a `SafeSpot` parser is a bad idea!
+func CMBUntilString(stop string) comb.Parser[string] {
+	var p comb.Parser[string]
+
+	expected := fmt.Sprintf("... %q", stop)
+
+	if stop == "" {
+		panic("stop is empty")
+	}
+
+	parse := func(state comb.State) (comb.State, string, *comb.ParserError) {
+		input := state.CurrentString()
+		i := strings.Index(input, stop)
+		if i == -1 {
+			return state, "", state.NewSyntaxError(expected)
+		}
+
+		newState := state.MoveBy(i + len(stop))
+		return newState, input[:i], nil
+	}
+
+	p = comb.NewParser[string](
+		expected,
+		parse,
+		func(state comb.State, _ interface{}) (int, interface{}) {
+			if strings.Contains(state.CurrentString(), stop) {
+				return 0, nil // this is probably not what the user wants but the only correct value :(
+			}
+			return comb.RecoverWasteTooMuch, nil
+		},
+	)
+	return p
 }
 
 // UntilString parses until it finds a token in the input and returns

--- a/experiments/parsify/parser_test.go
+++ b/experiments/parsify/parser_test.go
@@ -19,7 +19,7 @@ func TestDelimitedByChar(t *testing.T) {
 		{
 			name:           "normal parser without Parsify",
 			basicParser1:   C('{'),
-			complexParser1: cmb.Delimited(C('{'), cmb.UntilString("STOP"), C('}')),
+			complexParser1: cmb.Delimited(C('{'), CMBUntilString("STOP"), C('}')),
 		}, {
 			name:           "normal parser with Parsify",
 			basicParser2:   Char('{'),


### PR DESCRIPTION
Add parsers needed for `semtool`:

* `QuotedChar`
* `CharClassChar`
* `Sequence`
* `StringUntil` and `BytesUntil`

Remove `UntilString` parser since we have the more versatile `StringUntil` parser now.
Fix issues and add more tests.